### PR TITLE
add language metrics

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import TopNavigation from "@cloudscape-design/components/top-navigation";
 import Dashboard from "./components/Dashboard";
+import LanguageAnalytics from "./pages/LanguageAnalytics";
 
 const Home: React.FC = () => {
   return (
@@ -64,6 +65,11 @@ const App: React.FC = () => {
               text: "Reports",
               href: "/reports",
             },
+            {
+              type: "button",
+              text: "Language Analytics",
+              href: "/language-analytics",
+            },
           ]}
         />
 
@@ -71,6 +77,7 @@ const App: React.FC = () => {
           <Route path="/" element={<Home />} />
           <Route path="/on-demand-metrics" element={<OnDemandMetrics />} />
           <Route path="/reports" element={<Reports />} />
+          <Route path="/language-analytics" element={<LanguageAnalytics />} />
         </Routes>
 
         <Footer />

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useDataFiltering, DEFAULT_FILTERS } from './useDataFiltering';
 export { useCalculatedMetrics } from './useCalculatedMetrics';
+export { useLanguageMetrics } from './useLanguageMetrics';

--- a/frontend/src/hooks/useLanguageMetrics.ts
+++ b/frontend/src/hooks/useLanguageMetrics.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+import { CopilotMetricsByLanguage } from '../types/model';
+import { LanguageMetricsService } from '../services/languageMetricsService';
+
+export const useLanguageMetrics = () => {
+  const [languageData, setLanguageData] = useState<CopilotMetricsByLanguage[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLanguageMetrics = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await LanguageMetricsService.getLanguageMetrics();
+      console.log("Language metrics API response:", response);
+      
+      if (response) {
+        setLanguageData(response);
+      } else {
+        setLanguageData([]);
+      }
+    } catch (error) {
+      console.error("Error fetching language metrics:", error);
+      setError(error instanceof Error ? error.message : 'An error occurred while fetching language metrics');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return {
+    languageData,
+    isLoading,
+    error,
+    fetchLanguageMetrics,
+  };
+};

--- a/frontend/src/services/languageMetricsService.ts
+++ b/frontend/src/services/languageMetricsService.ts
@@ -1,0 +1,28 @@
+import { CopilotMetricsByLanguage } from "../types/model/index";
+import axios from "axios";
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8000";
+
+export class LanguageMetricsService {
+  static async getLanguageMetrics(): Promise<CopilotMetricsByLanguage[]> {
+    try {
+      const url = `${API_BASE_URL}/copilot_metrics/language`;
+
+      const response = await axios.get<CopilotMetricsByLanguage[]>(url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error("Error fetching language metrics:", error);
+
+      if (axios.isAxiosError(error)) {
+        throw new Error(`Failed to fetch language metrics: ${error.message}`);
+      } else {
+        throw new Error("Failed to fetch language metrics: Unknown error");
+      }
+    }
+  }
+}

--- a/frontend/src/types/model/index.ts
+++ b/frontend/src/types/model/index.ts
@@ -39,3 +39,9 @@ export interface CodeLineMetrics {
 }
 
 export type CalculatedMetricsResponse = CodeLineMetrics | null;
+
+export interface CopilotMetricsByLanguage {
+  language: string;
+  percentage_code_acceptances: number;
+  percentage_lines_accepted: number;
+}


### PR DESCRIPTION
Frontend:
- add language enpoint service
- add page of language metrics

![image](https://github.com/user-attachments/assets/04f1096b-6e31-4c1a-bab9-c4676e5781cb)
