### PR TITLE
add copilot acceptance chart page

### DIFF
--- a/frontend/src/components/CopilotUsageChart.tsx
+++ b/frontend/src/components/CopilotUsageChart.tsx
@@ -1,0 +1,201 @@
+import React, { useEffect, useState } from "react";
+import { Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ComposedChart } from "recharts";
+import {
+  Container,
+  Header,
+  ContentLayout,
+  SpaceBetween,
+  Alert,
+  Spinner,
+  Box,
+  DatePicker,
+  FormField,
+  Form
+} from "@cloudscape-design/components";
+import { useCopilotUsersMetrics } from "../hooks/useCopilotUsersMetrics";
+import { CopilotUsersMetrics } from "../types/model";
+
+const CopilotUsageChart: React.FC = () => {
+  const { copilotUsersData, isLoading, error, fetchCopilotUsersMetrics } = useCopilotUsersMetrics();
+
+  // Add state for period selection
+  const [beginDate, setBeginDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
+
+  useEffect(() => {
+    fetchCopilotUsersMetrics();
+  }, [fetchCopilotUsersMetrics]);
+
+  interface ChartDataEntry {
+    date: Date;
+    total_code_assistant_users: number;
+    total_chat_users: number;
+  }
+
+  // Parse and map data
+  const chartData: ChartDataEntry[] = copilotUsersData.map((item: CopilotUsersMetrics) => ({
+    date: new Date(item.date),
+    total_code_assistant_users: parseFloat(item.total_code_assistant_users.toFixed(1)),
+    total_chat_users: parseFloat(item.total_chat_users.toFixed(1)),
+  }));
+
+  // Filter data by selected period
+  const filteredChartData = chartData.filter((entry) => {
+    const entryTime = entry.date.getTime();
+    const beginTime = beginDate ? new Date(beginDate).getTime() : -Infinity;
+    const endTime = endDate ? new Date(endDate).getTime() : Infinity;
+    return entryTime >= beginTime && entryTime <= endTime;
+  });
+
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div
+          style={{
+            backgroundColor: "#ffffff",
+            border: "1px solid #e9ecef",
+            borderRadius: "8px",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+            fontSize: "14px",
+            padding: "12px",
+          }}
+        >
+            <p style={{ color: "#232f3e", fontWeight: "bold", margin: "0 0 8px 0" }}>
+            {`Date: ${(() => {
+              const d = new Date(label);
+              const day = d.getDate().toString().padStart(2, "0");
+              const month = d.toLocaleString("en-US", { month: "short" }).toLowerCase();
+              const year = d.getFullYear();
+              return `${day}-${month}-${year}`;
+            })()}`}
+            </p>
+          {payload.map((entry: any, index: number) => (
+            <p key={index} style={{ color: entry.color, margin: "4px 0" }}>
+              {`${entry.name}: ${entry.value.toLocaleString(undefined, {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0
+              })}`}
+            </p>
+          ))}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <SpaceBetween size="l">
+      {/* Period selection inputs - copied design from RequestParamsForm.tsx */}
+      <Form>
+        <SpaceBetween size="m" direction="horizontal">
+          <FormField label="Beginning period">
+            <DatePicker
+              value={beginDate}
+              onChange={({ detail }) => setBeginDate(detail.value)}
+              placeholder="YYYY-MM-DD"
+              openCalendarAriaLabel={() => "Open calendar"}
+            />
+          </FormField>
+          <FormField label="Ending period">
+            <DatePicker
+              value={endDate}
+              onChange={({ detail }) => setEndDate(detail.value)}
+              placeholder="YYYY-MM-DD"
+              openCalendarAriaLabel={() => "Open calendar"}
+            />
+          </FormField>
+        </SpaceBetween>
+      </Form>
+      {/* Chart Section - total_code_assistant_users*/}
+      <Container
+        header={
+          <Header
+            description="Number of users who used Copilot at least once per period"
+          >
+            Copilot Usage
+          </Header>
+        }
+      >
+        {isLoading && (
+          <Box textAlign="center" padding="xl">
+            <Spinner size="large" />
+            <Box variant="p" color="text-body-secondary">
+              Loading Copilot usage analytics...
+            </Box>
+          </Box>
+        )}
+
+        {error && (
+          <Alert statusIconAriaLabel="Error" type="error" header="Failed to load copilot usage analytics">
+            {error}
+          </Alert>
+        )}
+
+        {!isLoading && !error && filteredChartData.length > 0 && (
+          <div style={{ width: "100%", height: "500px" }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart
+                data={filteredChartData}
+                margin={{
+                  top: 20,
+                  right: 50,
+                  left: 20,
+                  bottom: 50,
+                }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+
+                <XAxis
+                  dataKey="date"
+                  angle={-45}
+                  textAnchor="end"
+                  height={100}
+                  fontSize={12}
+                  tickFormatter={(date) =>
+                    date instanceof Date
+                      ? date.toLocaleDateString()
+                      : new Date(date).toLocaleDateString()
+                  }
+                />
+
+                <YAxis
+                  yAxisId="left"
+                  label={{ value: "Number of different users", angle: -90, position: "insideLeft" }}
+                />
+
+                <Tooltip content={<CustomTooltip />} />
+                <Legend />
+
+                <Bar
+                  yAxisId="left"
+                  dataKey="total_code_assistant_users"
+                  fill="#8884d8"
+                  name="Number of different users who used Copilot"
+                />
+                <Bar
+                  yAxisId="left"
+                  dataKey="total_chat_users"
+                  fill="#82ca9d"
+                  name="Number of different users who accepted a Copilot suggestion"
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        {!isLoading && !error && filteredChartData.length === 0 && (
+          <Box textAlign="center" padding="xl">
+            <Box variant="h3" color="text-body-secondary">
+              No Copilot usage data available
+            </Box>
+            <Box variant="p" color="text-body-secondary">
+              There are no Copilot usage analytics to display at the moment.
+            </Box>
+          </Box>
+        )}
+      </Container>
+    </SpaceBetween>
+  );
+};
+
+export default CopilotUsageChart;

--- a/frontend/src/components/SuggestionAcceptanceChart.tsx
+++ b/frontend/src/components/SuggestionAcceptanceChart.tsx
@@ -1,0 +1,256 @@
+import React, { useState, useEffect } from "react";
+import {
+  Container,
+  Header,
+  FormField,
+  Select,
+  SelectProps,
+  SpaceBetween,
+  Box,
+} from "@cloudscape-design/components";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import { CopilotMetricsByPeriodService } from "../services/copilotMetricsByPeriodService";
+import { CopilotMetricsByPeriod } from "../types/model/index";
+
+interface ChartData {
+  period: string;
+  suggested: number;
+  accepted: number;
+}
+
+interface SuggestionsChartData {
+  period: string;
+  suggested: number;
+  accepted: number;
+}
+
+const SuggestionAcceptanceChart: React.FC = () => {
+  const [period, setPeriod] = useState<"W" | "M" | "Q" | "Y">("M");
+  const [data, setData] = useState<CopilotMetricsByPeriod[]>([]);
+  const [chartData, setChartData] = useState<ChartData[]>([]);
+  const [suggestionsChartData, setSuggestionsChartData] = useState<SuggestionsChartData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const periodOptions: SelectProps.Option[] = [
+    { label: "Weekly", value: "W" },
+    { label: "Monthly", value: "M" },
+    { label: "Quarterly", value: "Q" },
+    { label: "Yearly", value: "Y" },
+  ];
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await CopilotMetricsByPeriodService.getCopilotMetricsByPeriod(period);
+      setData(result);
+
+      // Transform data for the Lines of Code chart
+      const transformedData: ChartData[] = result.map((item, index) => {
+        const startDate = new Date(item.period_initial_date);
+        const periodLabel = startDate.toLocaleDateString();
+
+        // Calculate total suggested lines from acceptance ratio and accepted lines
+        // percentage_lines_accepted is actually a ratio (0-1), not a percentage (0-100)
+        const totalSuggested = item.total_lines_accepted > 0 && item.percentage_lines_accepted > 0
+          ? Math.round(item.total_lines_accepted / item.percentage_lines_accepted)
+          : item.total_lines_accepted;
+
+        return {
+          period: periodLabel,
+          suggested: totalSuggested,
+          accepted: item.total_lines_accepted,
+        };
+      });
+
+      // Transform data for the Number of Suggestions chart
+      const transformedSuggestionsData: SuggestionsChartData[] = result.map((item, index) => {
+        const startDate = new Date(item.period_initial_date);
+        const periodLabel = startDate.toLocaleDateString();
+
+        // Calculate total suggested code suggestions from acceptance ratio and accepted suggestions
+        // percentage_code_acceptances is actually a ratio (0-1), not a percentage (0-100)
+        const totalCodeSuggestions = item.total_code_acceptances > 0 && item.percentage_code_acceptances > 0
+          ? Math.round(item.total_code_acceptances / item.percentage_code_acceptances)
+          : item.total_code_acceptances;
+
+        return {
+          period: periodLabel,
+          suggested: totalCodeSuggestions,
+          accepted: item.total_code_acceptances,
+        };
+      });
+
+      setChartData(transformedData);
+      setSuggestionsChartData(transformedSuggestionsData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [period]);
+
+  const customTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      const suggested = payload.find((p: any) => p.dataKey === 'suggested')?.value || 0;
+      const accepted = payload.find((p: any) => p.dataKey === 'accepted')?.value || 0;
+      const acceptanceRate = suggested > 0 ? ((accepted / suggested) * 100).toFixed(1) : 0;
+
+      return (
+        <div style={{
+          backgroundColor: '#ffffff',
+          padding: '10px',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+        }}>
+          <p style={{ margin: '0 0 5px 0', fontWeight: 'bold' }}>{label}</p>
+          <p style={{ margin: '0 0 5px 0', color: '#8884d8' }}>
+            Lines Suggested: {suggested.toLocaleString()}
+          </p>
+          <p style={{ margin: '0 0 5px 0', color: '#82ca9d' }}>
+            Lines Accepted: {accepted.toLocaleString()}
+          </p>
+          <p style={{ margin: '0', color: '#666' }}>
+            Acceptance Rate: {acceptanceRate}%
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const customSuggestionsTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      const suggested = payload.find((p: any) => p.dataKey === 'suggested')?.value || 0;
+      const accepted = payload.find((p: any) => p.dataKey === 'accepted')?.value || 0;
+      const acceptanceRate = suggested > 0 ? ((accepted / suggested) * 100).toFixed(1) : 0;
+
+      return (
+        <div style={{
+          backgroundColor: '#ffffff',
+          padding: '10px',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+        }}>
+          <p style={{ margin: '0 0 5px 0', fontWeight: 'bold' }}>{label}</p>
+          <p style={{ margin: '0 0 5px 0', color: '#8884d8' }}>
+            Suggestions Made: {suggested.toLocaleString()}
+          </p>
+          <p style={{ margin: '0 0 5px 0', color: '#82ca9d' }}>
+            Suggestions Accepted: {accepted.toLocaleString()}
+          </p>
+          <p style={{ margin: '0', color: '#666' }}>
+            Acceptance Rate: {acceptanceRate}%
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Container
+      header={
+        <Header
+          description="Compare lines of code suggested by Copilot vs. accepted by users over time"
+        >
+          Suggestion Acceptance Chart
+        </Header>
+      }
+    >
+      <SpaceBetween direction="vertical" size="l">
+        <FormField label="Period">
+          <Select
+            selectedOption={periodOptions.find(option => option.value === period) || null}
+            onChange={({ detail }) => setPeriod(detail.selectedOption.value as "W" | "M" | "Q" | "Y")}
+            options={periodOptions}
+            placeholder="Select a period"
+          />
+        </FormField>
+
+        {error && (
+          <Box variant="div" padding="m" color="text-status-error">
+            Error: {error}
+          </Box>
+        )}
+
+        {loading ? (
+          <Box variant="div" textAlign="center" padding="l">
+            Loading chart data...
+          </Box>
+        ) : chartData.length > 0 ? (
+          <SpaceBetween direction="vertical" size="l">
+            {/* Lines of Code Chart */}
+            <Container
+              header={
+                <Header variant="h3">
+                  Lines of Code - Suggested vs Accepted
+                </Header>
+              }
+            >
+              <div style={{ width: '100%', height: '400px' }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={chartData} >
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="period"
+                      textAnchor="end"
+                      height={100}
+                      interval={0}
+                    />
+                    <YAxis />
+                    <Tooltip content={customTooltip} />
+                    <Legend verticalAlign="bottom" />
+                    <Bar dataKey="suggested" fill="#8884d8" name="Lines Suggested" />
+                    <Bar dataKey="accepted" fill="#82ca9d" name="Lines Accepted" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Container>
+
+            {/* Number of Suggestions Chart */}
+            <Container
+              header={
+                <Header variant="h3">
+                  Number of Suggestions - Made vs Accepted
+                </Header>
+              }
+            >
+              <div style={{ width: '100%', height: '400px' }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={suggestionsChartData} >
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="period"
+                      textAnchor="end"
+                      height={100}
+                      interval={0}
+                    />
+                    <YAxis />
+                    <Tooltip content={customSuggestionsTooltip} />
+                    <Legend verticalAlign="bottom" />
+                    <Bar dataKey="suggested" fill="#ff7c7c" name="Suggestions Made" />
+                    <Bar dataKey="accepted" fill="#4caf50" name="Suggestions Accepted" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Container>
+          </SpaceBetween>
+        ) : (
+          <Box variant="div" textAlign="center" padding="l">
+            No data available for the selected period
+          </Box>
+        )}
+      </SpaceBetween>
+    </Container>
+  );
+};
+
+export default SuggestionAcceptanceChart;

--- a/frontend/src/pages/CopilotAnalytics.tsx
+++ b/frontend/src/pages/CopilotAnalytics.tsx
@@ -1,87 +1,14 @@
-import React, { useEffect, useState } from "react";
-import { Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ComposedChart } from "recharts";
+import React, { useState } from "react";
 import {
-  Container,
   Header,
   ContentLayout,
-  SpaceBetween,
-  Alert,
-  Spinner,
-  Box,
-  DatePicker,
-  FormField,
-  Form
+  Tabs
 } from "@cloudscape-design/components";
-import { useCopilotUsersMetrics } from "../hooks/useCopilotUsersMetrics";
-import { CopilotUsersMetrics } from "../types/model";
+import CopilotUsageChart from "../components/CopilotUsageChart";
+import SuggestionAcceptanceChart from "../components/SuggestionAcceptanceChart";
 
 const CopilotAnalytics: React.FC = () => {
-  const { copilotUsersData, isLoading, error, fetchCopilotUsersMetrics } = useCopilotUsersMetrics();
-
-  // Add state for period selection
-  const [beginDate, setBeginDate] = useState<string>("");
-  const [endDate, setEndDate] = useState<string>("");
-
-  useEffect(() => {
-    fetchCopilotUsersMetrics();
-  }, [fetchCopilotUsersMetrics]);
-
-  interface ChartDataEntry {
-    date: Date;
-    total_code_assistant_users: number;
-    total_chat_users: number;
-  }
-
-  // Parse and map data
-  const chartData: ChartDataEntry[] = copilotUsersData.map((item: CopilotUsersMetrics) => ({
-    date: new Date(item.date),
-    total_code_assistant_users: parseFloat(item.total_code_assistant_users.toFixed(1)),
-    total_chat_users: parseFloat(item.total_chat_users.toFixed(1)),
-  }));
-
-  // Filter data by selected period
-  const filteredChartData = chartData.filter((entry) => {
-    const entryTime = entry.date.getTime();
-    const beginTime = beginDate ? new Date(beginDate).getTime() : -Infinity;
-    const endTime = endDate ? new Date(endDate).getTime() : Infinity;
-    return entryTime >= beginTime && entryTime <= endTime;
-  });
-
-  const CustomTooltip = ({ active, payload, label }: any) => {
-    if (active && payload && payload.length) {
-      return (
-        <div
-          style={{
-            backgroundColor: "#ffffff",
-            border: "1px solid #e9ecef",
-            borderRadius: "8px",
-            boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
-            fontSize: "14px",
-            padding: "12px",
-          }}
-        >
-            <p style={{ color: "#232f3e", fontWeight: "bold", margin: "0 0 8px 0" }}>
-            {`Date: ${(() => {
-              const d = new Date(label);
-              const day = d.getDate().toString().padStart(2, "0");
-              const month = d.toLocaleString("en-US", { month: "short" }).toLowerCase();
-              const year = d.getFullYear();
-              return `${day}-${month}-${year}`;
-            })()}`}
-            </p>
-          {payload.map((entry: any, index: number) => (
-            <p key={index} style={{ color: entry.color, margin: "4px 0" }}>
-              {`${entry.name}: ${entry.value.toLocaleString(undefined, {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0
-              })}`}
-            </p>
-          ))}
-        </div>
-      );
-    }
-    return null;
-  };
+  const [activeTabId, setActiveTabId] = useState("usage-chart");
 
   return (
     <div style={{ marginBottom: '25px' }}>
@@ -96,117 +23,22 @@ const CopilotAnalytics: React.FC = () => {
         }
         defaultPadding={true}
       >
-        <SpaceBetween size="l">
-          {/* Period selection inputs - copied design from RequestParamsForm.tsx */}
-          <Form>
-            <SpaceBetween size="m" direction="horizontal">
-              <FormField label="Beginning period">
-                <DatePicker
-                  value={beginDate}
-                  onChange={({ detail }) => setBeginDate(detail.value)}
-                  placeholder="YYYY-MM-DD"
-                  openCalendarAriaLabel={() => "Open calendar"}
-                />
-              </FormField>
-              <FormField label="Ending period">
-                <DatePicker
-                  value={endDate}
-                  onChange={({ detail }) => setEndDate(detail.value)}
-                  placeholder="YYYY-MM-DD"
-                  openCalendarAriaLabel={() => "Open calendar"}
-                />
-              </FormField>
-            </SpaceBetween>
-          </Form>
-          {/* Chart Section - total_code_assistant_users*/}
-          <Container
-            header={
-              <Header
-                description="Number of users who used Copilot at least once per period"
-              >
-                Copilot Usage
-              </Header>
+        <Tabs
+          activeTabId={activeTabId}
+          onChange={({ detail }) => setActiveTabId(detail.activeTabId)}
+          tabs={[
+            {
+              label: "Usage Chart",
+              id: "usage-chart",
+              content: <CopilotUsageChart />
+            },
+            {
+              label: "Suggestion Acceptance Chart",
+              id: "suggestion-acceptance-chart",
+              content: <SuggestionAcceptanceChart />
             }
-          >
-            {isLoading && (
-              <Box textAlign="center" padding="xl">
-                <Spinner size="large" />
-                <Box variant="p" color="text-body-secondary">
-                  Loading Copilot usage analytics...
-                </Box>
-              </Box>
-            )}
-
-            {error && (
-              <Alert statusIconAriaLabel="Error" type="error" header="Failed to load copilot usage analytics">
-                {error}
-              </Alert>
-            )}
-
-            {!isLoading && !error && filteredChartData.length > 0 && (
-              <div style={{ width: "100%", height: "500px" }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <ComposedChart
-                    data={filteredChartData}
-                    margin={{
-                      top: 20,
-                      right: 50,
-                      left: 20,
-                      bottom: 50,
-                    }}
-                  >
-                    <CartesianGrid strokeDasharray="3 3" />
-
-                    <XAxis
-                      dataKey="date"
-                      angle={-45}
-                      textAnchor="end"
-                      height={100}
-                      fontSize={12}
-                      tickFormatter={(date) =>
-                        date instanceof Date
-                          ? date.toLocaleDateString()
-                          : new Date(date).toLocaleDateString()
-                      }
-                    />
-
-                    <YAxis
-                      yAxisId="left"
-                      label={{ value: "Number of different users", angle: -90, position: "insideLeft" }}
-                    />
-
-                    <Tooltip content={<CustomTooltip />} />
-                    <Legend />
-
-                    <Bar
-                      yAxisId="left"
-                      dataKey="total_code_assistant_users"
-                      fill="#8884d8"
-                      name="Number of different users who used Copilot"
-                    />
-                    <Bar
-                      yAxisId="left"
-                      dataKey="total_chat_users"
-                      fill="#82ca9d"
-                      name="Number of different users who accepted a Copilot suggestion"
-                    />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              </div>
-            )}
-
-            {!isLoading && !error && filteredChartData.length === 0 && (
-              <Box textAlign="center" padding="xl">
-                <Box variant="h3" color="text-body-secondary">
-                  No Copilot usage data available
-                </Box>
-                <Box variant="p" color="text-body-secondary">
-                  There are no Copilot usage analytics to display at the moment.
-                </Box>
-              </Box>
-            )}
-          </Container>
-        </SpaceBetween>
+          ]}
+        />
       </ContentLayout>
     </div>
   );

--- a/frontend/src/services/copilotMetricsByPeriodService.ts
+++ b/frontend/src/services/copilotMetricsByPeriodService.ts
@@ -1,0 +1,33 @@
+import { CopilotMetricsByPeriod } from "../types/model/index";
+import axios from "axios";
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8000";
+
+export class CopilotMetricsByPeriodService {
+  static async getCopilotMetricsByPeriod(
+    period: "W" | "M" | "Q" | "Y"
+  ): Promise<CopilotMetricsByPeriod[]> {
+    try {
+      const queryParams = new URLSearchParams();
+      queryParams.append("period", period);
+
+      const url = `${API_BASE_URL}/copilot_metrics/period?${queryParams.toString()}`;
+
+      const response = await axios.get<CopilotMetricsByPeriod[]>(url, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error("Error fetching copilot metrics by period:", error);
+
+      if (axios.isAxiosError(error)) {
+        throw new Error(`Failed to fetch copilot metrics by period: ${error.message}`);
+      } else {
+        throw new Error("Failed to fetch copilot metrics by period: Unknown error");
+      }
+    }
+  }
+}

--- a/frontend/src/types/model/index.ts
+++ b/frontend/src/types/model/index.ts
@@ -55,3 +55,12 @@ export interface CopilotUsersMetrics {
   total_code_assistant_users: number;
   total_chat_users: number;
 }
+
+export interface CopilotMetricsByPeriod {
+  period_initial_date: string;
+  period_final_date: string;
+  percentage_code_acceptances: number;
+  total_code_acceptances: number;
+  percentage_lines_accepted: number;
+  total_lines_accepted: number;
+}


### PR DESCRIPTION
### Changes
- Moved existing code on `CopilotAnalytics` to `CopilotUsageChart`
- On `CopilotAnalytics` created a Tabs selector, one of which containing the `CopilotUsageChart`
- Created component and Tab for copilot acceptance charts page

### Description
This PR introduces the page of copilot suggestion acceptance rate.

The page has two graphs, one below the other, for both LoC and number of suggestions comparison.

User can select the period to analyze

<img width="1884" height="931" alt="image" src="https://github.com/user-attachments/assets/edcbac70-6117-4672-8180-2665ec4d8e44" />
